### PR TITLE
fix #41: Provide ClamAV integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,18 @@ A full set of usage instructions are provided by adding the ``--help`` argument:
             --announcedWebProtocol <arg>      The Protocol that is to be used by
                                               the end users. Defaults to the
                                               webProtocol value
+            --clamavHost <arg>                The FQDN or IP address of the host
+                                              running the optional ClamAV malware
+                                              scanner, if any.
+            --clamavPort <arg>                The TCP port number for the optional
+                                              ClamAV malware scanner, if any.
             --domain <arg>                    The domain that will be used for the
                                               component with the XMPP domain.
             --fileRepo <arg>                  Store files in a directory provided
                                               by the file system. Provide the
                                               desired path as a value. Path must
                                               exist.
-         -h,--help                            Displays this help text.
+            -h,--help                         Displays this help text.
             --maxFileSize <arg>               The maximum allowed size per file,
                                               in bytes. Use -1 to disable file
                                               size limit. Defaults to 5242880
@@ -108,3 +113,21 @@ A full set of usage instructions are provided by adding the ``--help`` argument:
             --xmppPort <arg>                  The TCP port number on the xmppHost,
                                               to which a connection will be made.
                                               Defaults to 5275.
+
+Scanning for Malware
+--------------------
+To facilitate virus scanning, you can configure the application to use ClamAV. ClamAV is a third-party, open source
+(GPLv2) anti-virus toolkit, available at https://www.clamav.net/
+
+To configure this application to use ClamAV, install, configure and run clamav-daemon, the scanner daemon of ClamAV.
+Configure the daemon in such a way that Openfire can access it via TCP.
+
+Note: ClamAV is configured with a maximum file size. Ensure that this is at least as big as the `maxFileSize` that is
+provided as an argument to the HTTP File Upload Component.
+
+Then, start the HTTP File Upload Component application with the `clamavHost` and `clamavPort` arguments. When these are
+provided, the application will supply each file that is being uploaded to the ClamAV daemon for scanning. A file upload
+will fail when the ClamAV daemon could not be reached, or, obviously, when it detects malware.
+
+While malware scanning can offer some protection against distributing unwanted content, it has limitations. Particularly
+when the uploaded data is encrypted, the scanner is unlikely able to detect any malware in it.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>nl.goodbytes.xmpp.xep</groupId>
   <artifactId>httpfileuploadcomponent</artifactId>
-  <version>1.5.1-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
 
   <name>HTTP File Upload Component</name>
   <description>Implementation of an XMPP External Component that implements XEP-0363 'HTTP File Upload'.</description>
@@ -164,6 +164,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>3.8.5</version>
+    </dependency>
+
+    <dependency>
+      <groupId>xyz.capybara</groupId>
+      <artifactId>clamav-client</artifactId>
+      <version>2.1.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/nl/goodbytes/xmpp/xep0363/MalwareDetectedException.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/MalwareDetectedException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Guus der Kinderen. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.goodbytes.xmpp.xep0363;
+
+public class MalwareDetectedException extends Exception
+{
+}

--- a/src/main/java/nl/goodbytes/xmpp/xep0363/MalwareScanner.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/MalwareScanner.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Guus der Kinderen. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.goodbytes.xmpp.xep0363;
+
+import java.io.IOException;
+
+public interface MalwareScanner
+{
+    void initialize() throws IOException;
+
+    void destroy();
+
+    void scan(final SecureUniqueId uuid) throws MalwareDetectedException, IOException;
+}

--- a/src/main/java/nl/goodbytes/xmpp/xep0363/MalwareScannerManager.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/MalwareScannerManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Guus der Kinderen. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.goodbytes.xmpp.xep0363;
+
+import java.io.IOException;
+
+public class MalwareScannerManager
+{
+    private static MalwareScannerManager INSTANCE;
+
+    public synchronized static MalwareScannerManager getInstance()
+    {
+        if (INSTANCE == null) {
+            INSTANCE = new MalwareScannerManager();
+        }
+
+        return INSTANCE;
+    }
+
+    private MalwareScanner malwareScanner;
+
+    public boolean isEnabled() {
+        return this.malwareScanner != null;
+    }
+
+    public void initialize(final MalwareScanner malwareScanner) throws IOException
+    {
+        if (this.malwareScanner != null) {
+            throw new IllegalArgumentException("Already initialized.");
+        }
+        this.malwareScanner = malwareScanner;
+        this.malwareScanner.initialize();
+    }
+
+    public MalwareScanner getMalwareScanner()
+    {
+        return this.malwareScanner;
+    }
+
+    public void destroy()
+    {
+        if (this.malwareScanner != null) {
+            this.malwareScanner.destroy();
+            this.malwareScanner = null;
+        }
+    }
+}

--- a/src/main/java/nl/goodbytes/xmpp/xep0363/Repository.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Guus der Kinderen. All rights reserved.
+ * Copyright (c) 2017-2023 Guus der Kinderen. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,4 +45,6 @@ public interface Repository
 
     // For writing data.
     OutputStream getOutputStream( SecureUniqueId uuid ) throws IOException;
+
+    boolean delete(SecureUniqueId uuid) throws IOException;
 }

--- a/src/main/java/nl/goodbytes/xmpp/xep0363/clamav/ClamavMalwareScanner.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/clamav/ClamavMalwareScanner.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 Guus der Kinderen. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.goodbytes.xmpp.xep0363.clamav;
+
+import nl.goodbytes.xmpp.xep0363.MalwareDetectedException;
+import nl.goodbytes.xmpp.xep0363.MalwareScanner;
+import nl.goodbytes.xmpp.xep0363.RepositoryManager;
+import nl.goodbytes.xmpp.xep0363.SecureUniqueId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import xyz.capybara.clamav.ClamavClient;
+import xyz.capybara.clamav.ClamavException;
+import xyz.capybara.clamav.commands.scan.result.ScanResult;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+
+public class ClamavMalwareScanner implements MalwareScanner
+{
+    private static final Logger Log = LoggerFactory.getLogger(ClamavMalwareScanner.class);
+
+    private final String hostname;
+
+    private final int port;
+
+    private final Duration connectTimeout;
+
+    private ClamavClient client;
+
+    public ClamavMalwareScanner(final String hostname, final int port, final Duration connectTimeout)
+    {
+        this.hostname = hostname;
+        this.port = port;
+        this.connectTimeout = connectTimeout.toMillis() > Integer.MAX_VALUE ? Duration.ofMillis(Integer.MAX_VALUE) : connectTimeout;
+    }
+
+    @Override
+    public synchronized void initialize() throws IOException
+    {
+        client = new ClamavClient(hostname, port);
+        if (!client.isReachable((int) connectTimeout.toMillis())) {
+            throw new IOException("Clamav daemon not reachable on " + hostname + ":" + port);
+        }
+
+        try {
+            final String version = client.version();
+            Log.info("Successfully connected to Clamav daemon " + version + ".");
+        } catch (Throwable t) {
+            Log.debug("Unable to determine Clamav daemon version.");
+            Log.info("Successfully connected to Clamav daemon!");
+        }
+    }
+
+    @Override
+    public synchronized void destroy()
+    {
+    }
+
+    @Override
+    public void scan(final SecureUniqueId uuid) throws MalwareDetectedException, IOException
+    {
+        synchronized (this) {
+            try {
+                client.ping();
+            } catch (ClamavException e) {
+                Log.info("Unsuccessful ping of the Clamav daemon. Trying to re-initialize the client.", e);
+                initialize();
+            }
+        }
+
+        try (final InputStream is = RepositoryManager.getInstance().getRepository().getInputStream(uuid)) {
+            final ScanResult scanResult = client.scan(is);
+            if (!(scanResult instanceof ScanResult.OK)) {
+                if (scanResult instanceof ScanResult.VirusFound) {
+                    ((ScanResult.VirusFound) scanResult).getFoundViruses().values()
+                        .forEach(malware -> Log.warn("Detected malware in slot '{}': {}", uuid, malware));
+                }
+                throw new MalwareDetectedException();
+            }
+        }
+    }
+}

--- a/src/main/java/nl/goodbytes/xmpp/xep0363/repository/AbstractFileSystemRepository.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/repository/AbstractFileSystemRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Guus der Kinderen. All rights reserved.
+ * Copyright (c) 2017-2023 Guus der Kinderen. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,6 +189,13 @@ public abstract class AbstractFileSystemRepository implements Repository
     {
         final Path path = Paths.get( repository.toString(), uuid.toString() );
         return Files.newOutputStream( path, CREATE );
+    }
+
+    @Override
+    public boolean delete( SecureUniqueId uuid ) throws IOException
+    {
+        final Path path = Paths.get( repository.toString(), uuid.toString() );
+        return Files.deleteIfExists( path );
     }
 
     public void purge() throws IOException


### PR DESCRIPTION
Adding a new feature that allows the application to be configured to send all uploaded content to an external process, a ClamAV daemon, that scans it for malware.