### PR TITLE
fix #46: Add Content-Security-Policy header

### DIFF
--- a/src/main/java/nl/goodbytes/xmpp/xep0363/Servlet.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 Guus der Kinderen. All rights reserved.
+ * Copyright (c) 2017-2024 Guus der Kinderen. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ public class Servlet extends HttpServlet
             response.setHeader("Access-Control-Allow-Methods", "PUT, GET, HEAD, OPTIONS");
             response.setHeader("Access-Control-Allow-Headers", "Overwrite, Destination, Content-Type, Depth, User-Agent, X-File-Size, X-Requested-With, If-Modified-Since, X-File-Name, Cache-Control");
         }
+        response.setHeader("Content-Security-Policy", "script-src ;");
         super.service(request, response);
     }
 


### PR DESCRIPTION
The added Content-Security-Policy header instructs browsers to not execute scripts that are served by the servlet.

It does so by defining an empty collection of valid sources for scripts.