### PR TITLE
Update Whack to 3.0.0 and Jetty to 12.0.14 (requires Java 17)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM maven:3-jdk-8
+FROM maven:3-eclipse-temurin-17
 COPY . .
 RUN mvn clean package
 
-FROM openjdk:8-jre-alpine
+FROM eclipse-temurin:17-alpine
 COPY --from=0 /target/httpfileuploadcomponent-*-SNAPSHOT-jar-with-dependencies.jar /opt/httpfileuploadcomponent.jar
 ENTRYPOINT ["java", "-jar", "/opt/httpfileuploadcomponent.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>nl.goodbytes.xmpp.xep</groupId>
   <artifactId>httpfileuploadcomponent</artifactId>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <name>HTTP File Upload Component</name>
   <description>Implementation of an XMPP External Component that implements XEP-0363 'HTTP File Upload'.</description>
@@ -73,8 +73,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
 
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.igniterealtime.whack</groupId>
       <artifactId>core</artifactId>
-      <version>2.0.1</version>
+      <version>3.0.0</version>
     </dependency>
 
     <dependency>
@@ -170,6 +170,18 @@
       <groupId>xyz.capybara</groupId>
       <artifactId>clamav-client</artifactId>
       <version>2.1.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>12.0.14</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee8</groupId>
+      <artifactId>jetty-ee8-servlet</artifactId>
+      <version>12.0.14</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/nl/goodbytes/xmpp/xep0363/Launcher.java
+++ b/src/main/java/nl/goodbytes/xmpp/xep0363/Launcher.java
@@ -22,9 +22,9 @@ import nl.goodbytes.xmpp.xep0363.repository.DirectoryRepository;
 import nl.goodbytes.xmpp.xep0363.repository.TempDirectoryRepository;
 import nl.goodbytes.xmpp.xep0363.slot.DefaultSlotProvider;
 import org.apache.commons.cli.*;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
-import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.server.ServerConnector;
 import org.jivesoftware.whack.ExternalComponentManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -411,7 +411,7 @@ public class Launcher
 
             jetty = new Server();
 
-            final SelectChannelConnector connector = new SelectChannelConnector();
+            final ServerConnector connector = new ServerConnector(jetty);
             connector.setHost( webHost );
             connector.setPort( webPort );
             jetty.addConnector( connector );


### PR DESCRIPTION
Whack 3.0.0 brings generic improvements, but drops Jetty support (it was providing a very old version).

In this commit, an explicit dependency to a recent version of Jetty (12.0.14) was defined. As a result, the minimum version of Java is now 17.

fixes #52
fixes #51